### PR TITLE
Add possibility to disable agent on matching hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In addition to the environment variables shown above, there are a number of othe
 | DD_APM_ENABLED | *Optional.* When set, this will start the Datadog Trace agent. |
 | DD_SERVICE_NAME | *Optional.* While not read directly by the Datadog Trace agent, we highly recommend that you set an environment variable for your service name. See the [Service Name](#service-name) section below for more information. |
 | DD_SERVICE_ENV | *Optional.* The Datadog Trace agent will automatically try to identify your environment by searching for a tag in the form `env:<your environment name>`. If you do not set a tag or wish to override an exsting tag, you can set the environment with this setting. For more information, see the [Datadog Tracing environments] page. |
+| DD_IGNORE_HOST | *Optional.* Disable datadog agent on matching hosts. For example, it can be useful to ignore Heroku `scheduler` that are launched |
 
 ### Histogram percentiles
 

--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -24,6 +24,11 @@ else
   DISABLE_DATADOG_AGENT=1
 fi
 
+# match ignored hosts and disable agent
+if [[ $DD_IGNORE_HOST ]] && [[ $DYNO == *"$DD_IGNORE_HOST"* ]]; then
+  echo "$DD_IGNORE_HOST set to be ignored, disabling datadog agent"
+  DISABLE_DATADOG_AGENT=1
+fi
 
 if [[ $DD_APM_ENABLED ]]; then
   sed -i -e "s/^[# ]*apm_enabled:.*$/apm_enabled: true/" $DD_AGENT_CONF


### PR DESCRIPTION
This commit adds the possibility to disable the datadog agent on hosts that match `$DD_IGNORE_HOST`.

This is useful to ignore the Heroku Scheduler dynos that are launched quite often, and for which we are billed - although we don't particularly care to get stats inside Heroku.

Once merged, I'll set `DD_IGNORE_HOST=scheduler` on prod, and it will be taken into account after the next deployment/build.

It was successfully tested on the staging app, ignoring the delayedworker or web.