### PR TITLE
Pin dd-agent version to 5.21.2

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -52,7 +52,7 @@ apt-get $APT_OPTIONS update | indent
 
 # Installing the Datadog Trace Agent will also install the Datadog Agent.
 topic "Fetching Datadog Agent and Trace Agent"
-apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommends datadog-agent | indent
+apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommends datadog-agent=1:5.21.2-1 | indent
 
 # Install the latest agent package.
 topic "Fetching deb packages"


### PR DESCRIPTION
This commit will pin the `datadog-agent` version to `5.21.2` and avoid the breaking change in `check.d` that was introduced in the next version.